### PR TITLE
Make clear that JSON_CONTAINS need a JSON encoded string

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $q = $queryBuilder
   ->where("JSON_CONTAINS(c.attributes, :certificates, '$.certificates') = 1");
 
 $result = $q->execute(array(
-  'certificates' => '"BIO"',
+  'certificates' => json_encode('BIO'),
 ));
 ```
 


### PR DESCRIPTION
As i did set `$queryBuilder->setParameter('myparam', $myParam);` I got 

> SQLSTATE[22032]: <<Unknown error>>: 3141 Invalid JSON text in argument 2 to function json_contains: "Invalid value." at position 0.

Hope this helps others to make clear that the given parameter need to be json encoded.