### PR TITLE
Prevent installing incompatible version of doctrine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,10 @@
 			"Scienta\\DoctrineJsonFunctions\\" : "src/"
 		}
 	},
+    "conflict": {
+        "doctrine/orm": "<2.7,>=3.0",
+        "doctrine/dbal": ">=3.0"
+	},
 	"autoload-dev": {
 		"psr-4": {
 			"Doctrine\\Tests\\": "tests/Doctrine/Tests",


### PR DESCRIPTION
part of #74

This PR adds a conflict rule on untested version of doctrine dbal and orm