### PR TITLE
Make code compatible (and requiring) Doctrine ORM 2.10 and DBAL 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,49 +1,60 @@
 {
-	"name": "scienta/doctrine-json-functions",
+    "name": "scienta/doctrine-json-functions",
     "abandoned": false,
-	"type": "library",
-	"description": "A set of extensions to Doctrine 2 that add support for json query functions.",
-	"keywords": ["doctrine", "orm", "json", "dql", "database", "mysql", "postgres", "postgresql", "mariadb", "sqlite"],
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "Doctrine Json Functions Contributors",
-			"homepage": "https://github.com/ScientaNL/DoctrineJsonFunctions/contributors"
-		}
-	],
-	"require": {
-		"php": "^7.1 || ^8.0",
-		"ext-pdo": "*",
-		"doctrine/orm": "2.*",
-		"doctrine/dbal": "3.*"
-	},
-	"require-dev": {
-		"doctrine/coding-standard": "^8.0 || ^9.0",
-		"phpunit/phpunit": "^8.0 || ^9.0"
-	},
-	"autoload": {
-		"psr-4": {
-			"Scienta\\DoctrineJsonFunctions\\" : "src/"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"Doctrine\\Tests\\": "tests/Doctrine/Tests",
-			"Scienta\\DoctrineJsonFunctions\\Tests\\": "tests/"
-		}
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-master": "4.1-dev"
-		}
-	},
-	"suggest": {
-		"dunglas/doctrine-json-odm": "To serialize / deserialize objects as JSON documents."
-	},
-	"config": {
-		"allow-plugins": {
-			"composer/package-versions-deprecated": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
-	}
+    "type": "library",
+    "description": "A set of extensions to Doctrine 2 that add support for json query functions.",
+    "keywords": [
+        "doctrine",
+        "orm",
+        "json",
+        "dql",
+        "database",
+        "mysql",
+        "postgres",
+        "postgresql",
+        "mariadb",
+        "sqlite"
+    ],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Doctrine Json Functions Contributors",
+            "homepage": "https://github.com/ScientaNL/DoctrineJsonFunctions/contributors"
+        }
+    ],
+    "require": {
+        "php": "^7.1 || ^8.0",
+        "ext-pdo": "*",
+        "doctrine/orm": "2.*",
+        "doctrine/dbal": "3.*"
+    },
+    "require-dev": {
+        "doctrine/coding-standard": "^8.0 || ^9.0",
+        "phpunit/phpunit": "^8.0 || ^9.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Scienta\\DoctrineJsonFunctions\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Doctrine\\Tests\\": "tests/Doctrine/Tests",
+            "Scienta\\DoctrineJsonFunctions\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "4.1-dev"
+        }
+    },
+    "suggest": {
+        "dunglas/doctrine-json-odm": "To serialize / deserialize objects as JSON documents."
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,10 @@
 	"require": {
 		"php": "^7.1 || ^8.0",
 		"ext-pdo": "*",
-		"doctrine/orm": "~2.*",
-		"doctrine/dbal": "~2.*"
+		"doctrine/orm": "2.*",
+		"doctrine/dbal": "3.*"
 	},
 	"require-dev": {
-		"doctrine/orm": "^2.7",
 		"doctrine/coding-standard": "^8.0 || ^9.0",
 		"phpunit/phpunit": "^8.0 || ^9.0"
 	},
@@ -40,5 +39,11 @@
 	},
 	"suggest": {
 		"dunglas/doctrine-json-odm": "To serialize / deserialize objects as JSON documents."
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/package-versions-deprecated": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,15 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "ext-pdo": "*",
-        "doctrine/orm": "2.*",
-        "doctrine/dbal": "3.*"
+        "doctrine/orm": "^2.0",
+        "doctrine/dbal": "^3.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^8.0 || ^9.0",
-        "phpunit/phpunit": "^8.0 || ^9.0"
+        "phpunit/phpunit": "^8.0 || ^9.0",
+        "doctrine/annotations": "^1.13"
     },
     "autoload": {
         "psr-4": {

--- a/src/Query/AST/Functions/AbstractJsonFunctionNode.php
+++ b/src/Query/AST/Functions/AbstractJsonFunctionNode.php
@@ -2,7 +2,7 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Literal;
 use Doctrine\ORM\Query\AST\Node;
@@ -153,7 +153,7 @@ abstract class AbstractJsonFunctionNode extends FunctionNode
     /**
      * @param SqlWalker $sqlWalker
      * @return string
-     * @throws DBALException
+     * @throws Exception
      * @throws \Doctrine\ORM\Query\AST\ASTException
      */
     public function getSql(SqlWalker $sqlWalker): string
@@ -190,7 +190,7 @@ abstract class AbstractJsonFunctionNode extends FunctionNode
 
     /**
      * @param SqlWalker $sqlWalker
-     * @throws DBALException
+     * @throws Exception
      */
     abstract protected function validatePlatform(SqlWalker $sqlWalker): void;
 }

--- a/src/Query/AST/Functions/Mariadb/MariadbJsonFunctionNode.php
+++ b/src/Query/AST/Functions/Mariadb/MariadbJsonFunctionNode.php
@@ -2,8 +2,8 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mariadb;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonFunctionNode;
 
@@ -11,12 +11,12 @@ abstract class MariadbJsonFunctionNode extends AbstractJsonFunctionNode
 {
     /**
      * @param SqlWalker $sqlWalker
-     * @throws DBALException
+     * @throws Exception
      */
     protected function validatePlatform(SqlWalker$sqlWalker): void
     {
-        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof MySqlPlatform) {
-            throw DBALException::notSupported(static::FUNCTION_NAME);
+        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof MySQLPlatform) {
+            throw Exception::notSupported(static::FUNCTION_NAME);
         }
     }
 }

--- a/src/Query/AST/Functions/Mysql/JsonContains.php
+++ b/src/Query/AST/Functions/Mysql/JsonContains.php
@@ -2,13 +2,6 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
-
 /**
  * "JSON_CONTAINS" "(" StringPrimary "," StringPrimary {"," StringPrimary } ")"
  */

--- a/src/Query/AST/Functions/Mysql/JsonContainsPath.php
+++ b/src/Query/AST/Functions/Mysql/JsonContainsPath.php
@@ -2,7 +2,7 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 
@@ -15,7 +15,7 @@ class JsonContainsPath extends JsonSearch
 
     /**
      * @param Parser $parser
-     * @throws DBALException
+     * @throws Exception
      * @throws \Doctrine\ORM\Query\QueryException
      */
     public function parse(Parser $parser): void

--- a/src/Query/AST/Functions/Mysql/JsonExtract.php
+++ b/src/Query/AST/Functions/Mysql/JsonExtract.php
@@ -2,13 +2,6 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
-
 /**
  * "JSON_EXTRACT" "(" StringPrimary "," StringPrimary {"," StringPrimary }* ")"
  */

--- a/src/Query/AST/Functions/Mysql/JsonKeys.php
+++ b/src/Query/AST/Functions/Mysql/JsonKeys.php
@@ -2,13 +2,6 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
-
 /**
  * "JSON_KEYS" "(" StringPrimary {"," StringPrimary } ")"
  */

--- a/src/Query/AST/Functions/Mysql/JsonMerge.php
+++ b/src/Query/AST/Functions/Mysql/JsonMerge.php
@@ -2,13 +2,6 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
-
 /**
  * "JSON_MERGE" "(" StringPrimary "," StringPrimary { "," StringPrimary }* ")"
  */

--- a/src/Query/AST/Functions/Mysql/JsonMergePatch.php
+++ b/src/Query/AST/Functions/Mysql/JsonMergePatch.php
@@ -2,13 +2,6 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
-
 /**
  * "JSON_MERGE_PATCH" "(" StringPrimary "," StringPrimary { "," StringPrimary }* ")"
  */

--- a/src/Query/AST/Functions/Mysql/JsonOverlaps.php
+++ b/src/Query/AST/Functions/Mysql/JsonOverlaps.php
@@ -2,13 +2,6 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
-
 /**
  * "JSON_OVERLAPS" "(" StringPrimary "," StringPrimary ")"
  */

--- a/src/Query/AST/Functions/Mysql/JsonPretty.php
+++ b/src/Query/AST/Functions/Mysql/JsonPretty.php
@@ -2,13 +2,6 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
-
 /**
  * "JSON_PRETTY" "(" NewValue ")"
  */

--- a/src/Query/AST/Functions/Mysql/JsonQuote.php
+++ b/src/Query/AST/Functions/Mysql/JsonQuote.php
@@ -2,13 +2,6 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
-
 /**
  * "JSON_QUOTE" "(" NewValue ")"
  */

--- a/src/Query/AST/Functions/Mysql/JsonSearch.php
+++ b/src/Query/AST/Functions/Mysql/JsonSearch.php
@@ -2,7 +2,7 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
@@ -31,7 +31,7 @@ class JsonSearch extends MysqlJsonFunctionNode
 
     /**
      * @param Parser $parser
-     * @throws DBALException
+     * @throws Exception
      * @throws \Doctrine\ORM\Query\QueryException
      */
 	public function parse(Parser $parser): void
@@ -61,7 +61,7 @@ class JsonSearch extends MysqlJsonFunctionNode
 
 	/**
 	 * @param Parser $parser
-	 * @throws DBALException
+	 * @throws Exception
 	 * @return Node
 	 */
 	protected function parsePathMode(Parser $parser)
@@ -78,6 +78,6 @@ class JsonSearch extends MysqlJsonFunctionNode
             return $parser->Literal();
 		}
 
-		throw DBALException::notSupported("Mode '$value' is not supported by " . static::FUNCTION_NAME . ".");
+		throw Exception::notSupported("Mode '$value' is not supported by " . static::FUNCTION_NAME . ".");
 	}
 }

--- a/src/Query/AST/Functions/Mysql/JsonType.php
+++ b/src/Query/AST/Functions/Mysql/JsonType.php
@@ -2,13 +2,6 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
-use Doctrine\ORM\Query\AST\Functions\FunctionNode;
-use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\Parser;
-use Doctrine\ORM\Query\SqlWalker;
-
 /**
  * "JSON_TYPE" "(" StringPrimary ")"
  */

--- a/src/Query/AST/Functions/Mysql/MysqlJsonFunctionNode.php
+++ b/src/Query/AST/Functions/Mysql/MysqlJsonFunctionNode.php
@@ -2,8 +2,8 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonFunctionNode;
 
@@ -11,12 +11,12 @@ abstract class MysqlJsonFunctionNode extends AbstractJsonFunctionNode
 {
     /**
      * @param SqlWalker $sqlWalker
-     * @throws DBALException
+     * @throws Exception
      */
     protected function validatePlatform(SqlWalker$sqlWalker): void
     {
-        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof MySqlPlatform) {
-            throw DBALException::notSupported(static::FUNCTION_NAME);
+        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof MySQLPlatform) {
+            throw Exception::notSupported(static::FUNCTION_NAME);
         }
     }
 }

--- a/src/Query/AST/Functions/Postgresql/PostgresqlJsonFunctionNode.php
+++ b/src/Query/AST/Functions/Postgresql/PostgresqlJsonFunctionNode.php
@@ -2,8 +2,8 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Postgresql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonFunctionNode;
 
@@ -11,12 +11,12 @@ abstract class PostgresqlJsonFunctionNode extends AbstractJsonFunctionNode
 {
     /**
      * @param SqlWalker $sqlWalker
-     * @throws DBALException
+     * @throws Exception
      */
     protected function validatePlatform(SqlWalker$sqlWalker): void
     {
-        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof PostgreSqlPlatform) {
-            throw DBALException::notSupported(static::FUNCTION_NAME);
+        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof PostgreSQL94Platform) {
+            throw Exception::notSupported(static::FUNCTION_NAME);
         }
     }
 

--- a/src/Query/AST/Functions/Postgresql/PostgresqlJsonOperatorFunctionNode.php
+++ b/src/Query/AST/Functions/Postgresql/PostgresqlJsonOperatorFunctionNode.php
@@ -2,8 +2,8 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Postgresql;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonOperatorFunctionNode;
 
@@ -13,12 +13,12 @@ abstract class PostgresqlJsonOperatorFunctionNode extends AbstractJsonOperatorFu
 
     /**
      * @param SqlWalker $sqlWalker
-     * @throws DBALException
+     * @throws Exception
      */
     protected function validatePlatform(SqlWalker$sqlWalker): void
     {
-        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof PostgreSqlPlatform) {
-            throw DBALException::notSupported(static::FUNCTION_NAME);
+        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof PostgreSQL94Platform) {
+            throw Exception::notSupported(static::FUNCTION_NAME);
         }
     }
 

--- a/src/Query/AST/Functions/Sqlite/SqliteJsonFunctionNode.php
+++ b/src/Query/AST/Functions/Sqlite/SqliteJsonFunctionNode.php
@@ -2,7 +2,7 @@
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Sqlite;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonFunctionNode;
@@ -11,12 +11,12 @@ abstract class SqliteJsonFunctionNode extends AbstractJsonFunctionNode
 {
     /**
      * @param SqlWalker $sqlWalker
-     * @throws DBALException
+     * @throws Exception
      */
     protected function validatePlatform(SqlWalker$sqlWalker): void
     {
         if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
-            throw DBALException::notSupported(static::FUNCTION_NAME);
+            throw Exception::notSupported(static::FUNCTION_NAME);
         }
     }
 }

--- a/tests/Mocks/ConnectionMock.php
+++ b/tests/Mocks/ConnectionMock.php
@@ -4,6 +4,7 @@ namespace Scienta\DoctrineJsonFunctions\Tests\Mocks;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Result;
 
 /**
  * Mock class for Connection.
@@ -21,7 +22,7 @@ class ConnectionMock extends Connection
     private $_fetchOneException;
 
     /**
-     * @var Statement|null
+     * @var Result|null
      */
     private $_queryResult;
 
@@ -50,7 +51,7 @@ class ConnectionMock extends Connection
      * @param \Doctrine\DBAL\Driver              $driver
      * @param \Doctrine\DBAL\Configuration|null  $config
      * @param \Doctrine\Common\EventManager|null $eventManager
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Exception
      */
     public function __construct(array $params, $driver, $config = null, $eventManager = null)
     {
@@ -81,9 +82,11 @@ class ConnectionMock extends Connection
     /**
      * {@inheritdoc}
      */
-    public function executeUpdate($query, array $params = [], array $types = [])
+    public function executeUpdate($query, array $params = [], array $types = []):int
     {
         $this->_executeUpdates[] = ['query' => $query, 'params' => $params, 'types' => $types];
+
+        return 0;
     }
 
     /**
@@ -110,7 +113,7 @@ class ConnectionMock extends Connection
     /**
      * {@inheritdoc}
      */
-    public function query() : Statement
+    public function query(string $sql) : Result
     {
         return $this->_queryResult;
     }
@@ -169,9 +172,9 @@ class ConnectionMock extends Connection
     }
 
     /**
-     * @param Statement $result
+     * @param Result $result
      */
-    public function setQueryResult(Statement $result)
+    public function setQueryResult(Result $result)
     {
         $this->_queryResult = $result;
     }

--- a/tests/Mocks/DatabasePlatformMock.php
+++ b/tests/Mocks/DatabasePlatformMock.php
@@ -2,7 +2,7 @@
 
 namespace Scienta\DoctrineJsonFunctions\Tests\Mocks;
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
@@ -21,9 +21,12 @@ class DatabasePlatformMock extends AbstractPlatform
     private $_prefersIdentityColumns = true;
 
     /**
-     * @var bool
+     * {@inheritdoc}
      */
-    private $_prefersSequences = false;
+    public function supportsIdentityColumns() {
+        return true;
+    }
+
 
     /**
      * {@inheritdoc}
@@ -31,14 +34,6 @@ class DatabasePlatformMock extends AbstractPlatform
     public function prefersIdentityColumns()
     {
         return $this->_prefersIdentityColumns;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function prefersSequences()
-    {
-        return $this->_prefersSequences;
     }
 
     /**
@@ -111,16 +106,6 @@ class DatabasePlatformMock extends AbstractPlatform
     }
 
     /**
-     * @param bool $bool
-     *
-     * @return void
-     */
-    public function setPrefersSequences($bool)
-    {
-        $this->_prefersSequences = $bool;
-    }
-
-    /**
      * @param string $sql
      *
      * @return void
@@ -148,10 +133,14 @@ class DatabasePlatformMock extends AbstractPlatform
     /**
      * @param array $field
      * @return string|void
-     * @throws DBALException
+     * @throws Exception
      */
     public function getBlobTypeDeclarationSQL(array $field)
     {
-        throw DBALException::notSupported(__METHOD__);
+        throw Exception::notSupported(__METHOD__);
+    }
+
+    public function getCurrentDatabaseExpression(): string {
+        throw Exception::notSupported(__METHOD__);
     }
 }

--- a/tests/Mocks/DriverMock.php
+++ b/tests/Mocks/DriverMock.php
@@ -2,6 +2,9 @@
 
 namespace Scienta\DoctrineJsonFunctions\Tests\Mocks;
 
+use Doctrine\DBAL\Driver\API\ExceptionConverter;
+use Doctrine\DBAL\Exception;
+
 /**
  * Mock class for Driver.
  */
@@ -39,7 +42,7 @@ class DriverMock implements \Doctrine\DBAL\Driver
     /**
      * {@inheritdoc}
      */
-    public function getSchemaManager(\Doctrine\DBAL\Connection $conn)
+    public function getSchemaManager(\Doctrine\DBAL\Connection $conn, \Doctrine\DBAL\Platforms\AbstractPlatform $platform)
     {
         if ($this->_schemaManagerMock == null) {
             return new SchemaManagerMock($conn);
@@ -89,5 +92,9 @@ class DriverMock implements \Doctrine\DBAL\Driver
     public function convertExceptionCode(\Exception $exception)
     {
         return 0;
+    }
+
+    public function getExceptionConverter(): ExceptionConverter {
+        throw Exception::notSupported(__METHOD__);
     }
 }

--- a/tests/Query/Functions/Mysql/JsonArrayAppendTest.php
+++ b/tests/Query/Functions/Mysql/JsonArrayAppendTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonArrayAppendTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonArrayInsertTest.php
+++ b/tests/Query/Functions/Mysql/JsonArrayInsertTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonArrayInsertTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonArrayTest.php
+++ b/tests/Query/Functions/Mysql/JsonArrayTest.php
@@ -2,8 +2,8 @@
 
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
-use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
 use Doctrine\ORM\Query\Expr;
+use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
 
 class JsonArrayTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonContainsPathTest.php
+++ b/tests/Query/Functions/Mysql/JsonContainsPathTest.php
@@ -24,7 +24,7 @@ class JsonContainsPathTest extends MysqlTestCase
 
     public function testJsonContainsPathNone()
     {
-        $this->expectException(\Doctrine\DBAL\DBALException::class);
+        $this->expectException(\Doctrine\DBAL\Exception::class);
 
         $this->assertDqlProducesSql(
             "SELECT JSON_CONTAINS_PATH('{\"a\": 1, \"b\": 2, \"c\": {\"d\": 4}}', 'none', '$.a', '$.e') from Scienta\DoctrineJsonFunctions\Tests\Entities\Blank b",

--- a/tests/Query/Functions/Mysql/JsonContainsTest.php
+++ b/tests/Query/Functions/Mysql/JsonContainsTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonContainsTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonDepthTest.php
+++ b/tests/Query/Functions/Mysql/JsonDepthTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonDepthTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonExctractTest.php
+++ b/tests/Query/Functions/Mysql/JsonExctractTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonExctractTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonInsertTest.php
+++ b/tests/Query/Functions/Mysql/JsonInsertTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonInsertTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonKeysTest.php
+++ b/tests/Query/Functions/Mysql/JsonKeysTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonKeysTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonLengthTest.php
+++ b/tests/Query/Functions/Mysql/JsonLengthTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonLengthTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonMergePatchTest.php
+++ b/tests/Query/Functions/Mysql/JsonMergePatchTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonMergePatchTestTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonMergeTest.php
+++ b/tests/Query/Functions/Mysql/JsonMergeTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonMergeTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonObjectTest.php
+++ b/tests/Query/Functions/Mysql/JsonObjectTest.php
@@ -2,8 +2,8 @@
 
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
-use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
 use Doctrine\ORM\Query\Expr;
+use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
 
 class JsonObjectTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonOverlapsTest.php
+++ b/tests/Query/Functions/Mysql/JsonOverlapsTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonOverlapsTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonPrettyTest.php
+++ b/tests/Query/Functions/Mysql/JsonPrettyTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonPrettyTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonQuoteTest.php
+++ b/tests/Query/Functions/Mysql/JsonQuoteTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonQuoteTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonRemoveTest.php
+++ b/tests/Query/Functions/Mysql/JsonRemoveTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonRemoveTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonReplaceTest.php
+++ b/tests/Query/Functions/Mysql/JsonReplaceTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonReplaceTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonSearchTest.php
+++ b/tests/Query/Functions/Mysql/JsonSearchTest.php
@@ -31,7 +31,7 @@ class JsonSearchTest extends MysqlTestCase
 
     public function testJsonSearchNone()
     {
-        $this->expectException(\Doctrine\DBAL\DBALException::class);
+        $this->expectException(\Doctrine\DBAL\Exception::class);
 
         $this->assertDqlProducesSql(
             "SELECT JSON_SEARCH('[\"abc\", [{\"k\": \"10\"}, \"def\"], {\"x\":\"abc\"}, {\"y\":\"bcd\"}]', 'none', '$.a') from Scienta\DoctrineJsonFunctions\Tests\Entities\Blank b",

--- a/tests/Query/Functions/Mysql/JsonSetTest.php
+++ b/tests/Query/Functions/Mysql/JsonSetTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonSetTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonTypeTest.php
+++ b/tests/Query/Functions/Mysql/JsonTypeTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonTypeTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonUnquoteTest.php
+++ b/tests/Query/Functions/Mysql/JsonUnquoteTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonUnquoteTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Mysql/JsonValidTest.php
+++ b/tests/Query/Functions/Mysql/JsonValidTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonValidTest extends MysqlTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonArrayLengthTest.php
+++ b/tests/Query/Functions/Sqlite/JsonArrayLengthTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonArrayLengthTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonArrayTest.php
+++ b/tests/Query/Functions/Sqlite/JsonArrayTest.php
@@ -2,8 +2,8 @@
 
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
-use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
 use Doctrine\ORM\Query\Expr;
+use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
 
 class JsonArrayTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonExtractTest.php
+++ b/tests/Query/Functions/Sqlite/JsonExtractTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonExtractTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonGroupArrayTest.php
+++ b/tests/Query/Functions/Sqlite/JsonGroupArrayTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonGroupArrayTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonInsertTest.php
+++ b/tests/Query/Functions/Sqlite/JsonInsertTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonInsertTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonObjectTest.php
+++ b/tests/Query/Functions/Sqlite/JsonObjectTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonObjectTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonPatchTest.php
+++ b/tests/Query/Functions/Sqlite/JsonPatchTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonPatchTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonQuoteTest.php
+++ b/tests/Query/Functions/Sqlite/JsonQuoteTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonQuoteTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonRemoveTest.php
+++ b/tests/Query/Functions/Sqlite/JsonRemoveTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonRemoveTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonReplaceTest.php
+++ b/tests/Query/Functions/Sqlite/JsonReplaceTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonReplaceTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonSetTest.php
+++ b/tests/Query/Functions/Sqlite/JsonSetTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonSetTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonTest.php
+++ b/tests/Query/Functions/Sqlite/JsonTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonTypeTest.php
+++ b/tests/Query/Functions/Sqlite/JsonTypeTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonTypeTest extends SqliteTestCase
 {

--- a/tests/Query/Functions/Sqlite/JsonValidTest.php
+++ b/tests/Query/Functions/Sqlite/JsonValidTest.php
@@ -3,7 +3,6 @@
 namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Sqlite;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\SqliteTestCase;
-use Doctrine\ORM\Query\Expr;
 
 class JsonValidTest extends SqliteTestCase
 {

--- a/tests/Query/MariadbTestCase.php
+++ b/tests/Query/MariadbTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Scienta\DoctrineJsonFunctions\Tests\Query;
 
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Configuration;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mariadb as DqlFunctions;
 use Scienta\DoctrineJsonFunctions\Tests\Mocks\ConnectionMock;
@@ -15,7 +15,7 @@ abstract class MariadbTestCase extends DbTestCase
 
         /** @var ConnectionMock $conn */
         $conn = $this->entityManager->getConnection();
-        $conn->setDatabasePlatform(new MySqlPlatform());
+        $conn->setDatabasePlatform(new MySQLPlatform());
 
         self::loadDqlFunctions($this->configuration);
     }

--- a/tests/Query/MysqlTestCase.php
+++ b/tests/Query/MysqlTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Scienta\DoctrineJsonFunctions\Tests\Query;
 
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Configuration;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql as DqlFunctions;
 use Scienta\DoctrineJsonFunctions\Tests\Mocks\ConnectionMock;
@@ -15,7 +15,7 @@ abstract class MysqlTestCase extends DbTestCase
 
         /** @var ConnectionMock $conn */
         $conn = $this->entityManager->getConnection();
-        $conn->setDatabasePlatform(new MySqlPlatform());
+        $conn->setDatabasePlatform(new MySQLPlatform());
 
         self::loadDqlFunctions($this->configuration);
     }

--- a/tests/Query/PostgresqlTestCase.php
+++ b/tests/Query/PostgresqlTestCase.php
@@ -2,7 +2,7 @@
 
 namespace Scienta\DoctrineJsonFunctions\Tests\Query;
 
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\ORM\Configuration;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\Postgresql as DqlFunctions;
 use Scienta\DoctrineJsonFunctions\Tests\Mocks\ConnectionMock;
@@ -15,7 +15,7 @@ abstract class PostgresqlTestCase extends DbTestCase
 
         /** @var ConnectionMock $conn */
         $conn = $this->entityManager->getConnection();
-        $conn->setDatabasePlatform(new PostgreSqlPlatform());
+        $conn->setDatabasePlatform(new PostgreSQL94Platform());
 
         self::loadDqlFunctions($this->configuration);
     }


### PR DESCRIPTION
This PR updates the code and tests in order to be compatible with Doctrine ORM 2.10 and DBAL 3.0. 
This PR contains breaking changes and should result in a new major version.
The implementation of the platform mocks is a dummy one and the strict minimum in order to have green tests.

A lot of imports that were not used are also cleaned.

The package.json file makes sure to require Doctrine ORM and DBAL as this libs depends on them. 

Deprecations fixed:
- `Doctrine\DBAL\DBALException` was renamed to `Doctrine\DBAL\Exception`
- `Doctrine\DBAL\Platforms\MySqlPlatform` was renamed to `Doctrine\DBAL\Platforms\MySQLPlatform`
- `Doctrine\DBAL\Platforms\PostgreSqlPlatform` does not exist anymore and is replaced by `PostgreSql94Platform` and `PostgreSql100Platform`.
- `Doctrine\DBAL\Connection#query` now takes a `string` as parameter and returns a `Result`
- `Doctrine\DBAL\Connection#executeUpdate` now returns an int. Making `ConnectionMock#executeUpdate` return `0` to have green tests 
- `Doctrine\DBAL\Platforms\AbstractPlatform#prefersSequences` does not exist anymore
- The database platform mock must support an identity generator to have green tests. Making  `DatabasePlatformMock#supportsIdentityColumns` return true.
- `Doctrine\DBAL\Driver` has a new method: `getExceptionConverter`. Making the method throw in order to have the mock respect the interface and have green tests.
- `Doctrine\DBAL\Driver#getSchemaManager` now takes the platform as second argument.

Closes #74 