### PR TITLE
Implement missing MariaDB and update doc to indicate MySQL is compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ A set of extensions to Doctrine 2 that add support for json query functions.
 
 | DB | Functions |
 |:--:|:---------:|
-| MySQL | `JSON_APPEND, JSON_ARRAY, JSON_ARRAY_APPEND, JSON_ARRAY_INSERT, JSON_CONTAINS, JSON_CONTAINS_PATH, JSON_DEPTH, JSON_EXTRACT, JSON_OVERLAPS, JSON_INSERT, JSON_KEYS, JSON_LENGTH, JSON_MERGE, JSON_MERGE_PATCH, JSON_OBJECT, JSON_PRETTY, JSON_QUOTE, JSON_REMOVE, JSON_REPLACE, JSON_SEARCH, JSON_SET, JSON_TYPE, JSON_UNQUOTE, JSON_VALID` |
+| MySQL | `JSON_APPEND, JSON_ARRAY, JSON_ARRAY_APPEND, JSON_ARRAY_INSERT, JSON_CONTAINS, JSON_CONTAINS_PATH, JSON_DEPTH, JSON_EXTRACT, JSON_OVERLAPS, JSON_INSERT, JSON_KEYS, JSON_LENGTH, JSON_MERGE, JSON_MERGE_PRESERVE, JSON_MERGE_PATCH, JSON_OBJECT, JSON_PRETTY, JSON_QUOTE, JSON_REMOVE, JSON_REPLACE, JSON_SEARCH, JSON_SET, JSON_TYPE, JSON_UNQUOTE, JSON_VALID` |
 | PostgreSQL | `JSON_EXTRACT_PATH, GT, GT_GT, SHARP_GT, SHARP_GT_GT` |
-| MariaDb | `JSON_VALUE, JSON_EXISTS` |
+| MariaDb | `JSON_VALUE, JSON_EXISTS, JSON_QUERY, JSON_COMPACT, JSON_DETAILED, JSON_LOOSE, JSON_EQUALS, JSON_NORMALIZE` |
 | SQLite | `JSON, JSON_ARRAY, JSON_ARRAY_LENGTH, JSON_EXTRACT, JSON_GROUP_ARRAY, JSON_GROUP_OBJECT, JSON_INSERT, JSON_OBJECT, JSON_PATCH, JSON_QUOTE, JSON_REMOVE, JSON_REPLACE, JSON_SET, JSON_TYPE, JSON_VALID` |
 
 Table of Contents
@@ -193,6 +193,8 @@ The library provides this set of DQL functions.
 	- Returns the length of JSON document, or, if a path argument is given, the length of the value within the document identified by the path.
 * [JSON_MERGE(json_doc, json_doc[, json_doc] ...)](https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-merge)
 	- Merges two or more JSON documents and returns the merged result.
+* [JSON_MERGE_PRESERVE(json_doc, json_doc[, json_doc] ...)](https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-merge_preserve)
+	- Merges two or more JSON documents and returns the merged result. Returns NULL if any argument is NULL. An error occurs if any argument is not a valid JSON document.
 * [JSON_MERGE_PATCH(json_doc, json_doc[, json_doc] ...)](https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-merge-patch)
     - Performs an RFC 7396 compliant merge of two or more JSON documents and returns the merged result.
 * [JSON_OBJECT([key, val[, key, val] ...])](https://dev.mysql.com/doc/refman/5.7/en/json-creation-functions.html#function_json-object)
@@ -216,11 +218,29 @@ The library provides this set of DQL functions.
 * [JSON_VALID(val)](https://dev.mysql.com/doc/refman/5.7/en/json-attribute-functions.html#function_json-valid)
 	- Returns 0 or 1 to indicate whether a value is a valid JSON document.
 
+Note that you can use MySQL Operators with MariaDb database if compatible.
+
 ### MariaDb 10.2.3 JSON operators
-* [JSON_VALUE(json_doc, path)](https://mariadb.com/kb/en/library/json_value/)
+* [JSON_VALUE(json_doc, path)](https://mariadb.com/kb/en/json_value/)
 	- Returns the scalar specified by the path. Returns NULL if there is no match.
-* [JSON_EXISTS(json_doc, path)](https://mariadb.com/kb/en/library/json_exists/)
+* [JSON_EXISTS(json_doc, path)](https://mariadb.com/kb/en/json_exists/)
     - Determines whether a specified JSON value exists in the given data. Returns 1 if found, 0 if not, or NULL if any of the inputs were NULL.
+* [JSON_QUERY(json_doc, path)](https://mariadb.com/kb/en/json_query/)
+	- Given a JSON document, returns an object or array specified by the path. Returns NULL if not given a valid JSON document, or if there is no match.
+
+### MariaDb 10.2.4 JSON operators
+* [JSON_COMPACT(json_doc)](https://mariadb.com/kb/en/json_compact/)
+	- Removes all unnecessary spaces so the json document is as short as possible.
+* [JSON_DETAILED(json_doc[, tab_size])](https://mariadb.com/kb/en/json_detailed/)
+	- Represents JSON in the most understandable way emphasizing nested structures.
+* [JSON_LOOSE(json_doc)](https://mariadb.com/kb/en/json_loose/)
+	- Adds spaces to a JSON document to make it look more readable.
+
+### MariaDb 10.7.0 JSON operators
+* [JSON_EQUALS(json_doc, json_doc)](https://mariadb.com/kb/en/json_equals/)
+	- Checks if there is equality between two json objects. Returns 1 if it there is, 0 if not, or NULL if any of the arguments are null.
+* [JSON_NORMALIZE(json_doc)](https://mariadb.com/kb/en/json_normalize/)
+	- Recursively sorts keys and removes spaces, allowing comparison of json documents for equality.
 
 ### PostgreSQL 9.3+ JSON operators
 Basic support for JSON operators is implemented. This works even with `Doctrine\DBAL` v2.5. [Official documentation of JSON operators](https://www.postgresql.org/docs/9.3/static/functions-json.html).

--- a/src/Query/AST/Functions/Mariadb/JsonCompact.php
+++ b/src/Query/AST/Functions/Mariadb/JsonCompact.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mariadb;
+
+/**
+ * "JSON_COMPACT" "(" StringPrimary ")"
+ */
+class JsonCompact extends MariadbJsonFunctionNode
+{
+    public const FUNCTION_NAME = 'JSON_COMPACT';
+
+    /** @var string[] */
+    protected $requiredArgumentTypes = [self::STRING_PRIMARY_ARG];
+}

--- a/src/Query/AST/Functions/Mariadb/JsonDetailed.php
+++ b/src/Query/AST/Functions/Mariadb/JsonDetailed.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mariadb;
+
+/**
+ * "JSON_DETAILED" "(" StringPrimary " {, " alphaNumeric "})"
+ */
+class JsonDetailed extends MariadbJsonFunctionNode
+{
+    public const FUNCTION_NAME = 'JSON_DETAILED';
+
+    /** @var string[] */
+    protected $requiredArgumentTypes = [self::STRING_PRIMARY_ARG];
+
+    /** @var string[] */
+    protected $optionalArgumentTypes = [self::ALPHA_NUMERIC];
+}

--- a/src/Query/AST/Functions/Mariadb/JsonEquals.php
+++ b/src/Query/AST/Functions/Mariadb/JsonEquals.php
@@ -3,11 +3,11 @@
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mariadb;
 
 /**
- * "JSON_EXISTS" "(" StringPrimary "," StringPrimary ")"
+ * "JSON_EQUALS" "(" StringPrimary ", " StringPrimary ")"
  */
-class JsonExists extends MariadbJsonFunctionNode
+class JsonEquals extends MariadbJsonFunctionNode
 {
-    public const FUNCTION_NAME = 'JSON_EXISTS';
+    public const FUNCTION_NAME = 'JSON_EQUALS';
 
     /** @var string[] */
     protected $requiredArgumentTypes = [self::STRING_PRIMARY_ARG, self::STRING_PRIMARY_ARG];

--- a/src/Query/AST/Functions/Mariadb/JsonLoose.php
+++ b/src/Query/AST/Functions/Mariadb/JsonLoose.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mariadb;
+
+/**
+ * "JSON_LOOSE" "(" StringPrimary ")"
+ */
+class JsonLoose extends MariadbJsonFunctionNode
+{
+    public const FUNCTION_NAME = 'JSON_LOOSE';
+
+    /** @var string[] */
+    protected $requiredArgumentTypes = [self::STRING_PRIMARY_ARG];
+}

--- a/src/Query/AST/Functions/Mariadb/JsonNormalize.php
+++ b/src/Query/AST/Functions/Mariadb/JsonNormalize.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mariadb;
+
+/**
+ * "JSON_NORMALIZE" "(" StringPrimary ")"
+ */
+class JsonNormalize extends MariadbJsonFunctionNode
+{
+    public const FUNCTION_NAME = 'JSON_NORMALIZE';
+
+    /** @var string[] */
+    protected $requiredArgumentTypes = [self::STRING_PRIMARY_ARG];
+}

--- a/src/Query/AST/Functions/Mariadb/JsonQuery.php
+++ b/src/Query/AST/Functions/Mariadb/JsonQuery.php
@@ -3,11 +3,11 @@
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mariadb;
 
 /**
- * "JSON_EXISTS" "(" StringPrimary "," StringPrimary ")"
+ * "JSON_QUERY" "(" StringPrimary "," StringPrimary ")"
  */
-class JsonExists extends MariadbJsonFunctionNode
+class JsonQuery extends MariadbJsonFunctionNode
 {
-    public const FUNCTION_NAME = 'JSON_EXISTS';
+    public const FUNCTION_NAME = 'JSON_QUERY';
 
     /** @var string[] */
     protected $requiredArgumentTypes = [self::STRING_PRIMARY_ARG, self::STRING_PRIMARY_ARG];

--- a/src/Query/AST/Functions/Mysql/JsonMergePreserve.php
+++ b/src/Query/AST/Functions/Mysql/JsonMergePreserve.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
+
+/**
+ * "JSON_MERGE_PRESERVE" "(" StringPrimary "," StringPrimary { "," StringPrimary }* ")"
+ */
+class JsonMergePreserve extends MysqlJsonFunctionNode
+{
+	const FUNCTION_NAME = 'JSON_MERGE_PRESERVE';
+
+    /** @var string[] */
+    protected $requiredArgumentTypes = [self::STRING_PRIMARY_ARG, self::STRING_PRIMARY_ARG];
+
+    /** @var string[] */
+    protected $optionalArgumentTypes = [self::STRING_PRIMARY_ARG];
+
+    /** @var bool */
+    protected $allowOptionalArgumentRepeat = true;
+}

--- a/tests/Query/Functions/Mariadb/JsonCompactTest.php
+++ b/tests/Query/Functions/Mariadb/JsonCompactTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mariadb;
+
+use Scienta\DoctrineJsonFunctions\Tests\Query\MariadbTestCase;
+
+class JsonCompactTest extends MariadbTestCase
+{
+    public function testJsonCompact()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSON_COMPACT('{\"key1\":123}') from Scienta\DoctrineJsonFunctions\Tests\Entities\Blank b",
+            "SELECT JSON_COMPACT('{\"key1\":123}') AS sclr_0 FROM Blank b0_"
+        );
+    }
+}

--- a/tests/Query/Functions/Mariadb/JsonDetailedTest.php
+++ b/tests/Query/Functions/Mariadb/JsonDetailedTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mariadb;
+
+use Scienta\DoctrineJsonFunctions\Tests\Query\MariadbTestCase;
+
+class JsonDetailedTest extends MariadbTestCase
+{
+    public function testJsonDetailed()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSON_DETAILED('{\"key1\":123}') from Scienta\DoctrineJsonFunctions\Tests\Entities\Blank b",
+            "SELECT JSON_DETAILED('{\"key1\":123}') AS sclr_0 FROM Blank b0_"
+        );
+    }
+
+    public function testJsonDetailedMore()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSON_DETAILED('{\"key1\":123}', 4) from Scienta\DoctrineJsonFunctions\Tests\Entities\Blank b",
+            "SELECT JSON_DETAILED('{\"key1\":123}', 4) AS sclr_0 FROM Blank b0_"
+        );
+    }
+}

--- a/tests/Query/Functions/Mariadb/JsonEqualsTest.php
+++ b/tests/Query/Functions/Mariadb/JsonEqualsTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mariadb;
+
+use Scienta\DoctrineJsonFunctions\Tests\Query\MariadbTestCase;
+
+class JsonEqualsTest extends MariadbTestCase
+{
+    public function testJsonEquals()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSON_EQUALS('{\"key1\":123}', '{\"key1\":123}') from Scienta\DoctrineJsonFunctions\Tests\Entities\Blank b",
+            "SELECT JSON_EQUALS('{\"key1\":123}', '{\"key1\":123}') AS sclr_0 FROM Blank b0_"
+        );
+    }
+}

--- a/tests/Query/Functions/Mariadb/JsonLooseTest.php
+++ b/tests/Query/Functions/Mariadb/JsonLooseTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mariadb;
+
+use Scienta\DoctrineJsonFunctions\Tests\Query\MariadbTestCase;
+
+class JsonLooseTest extends MariadbTestCase
+{
+    public function testJsonLoose()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSON_LOOSE('{\"key1\":123}') from Scienta\DoctrineJsonFunctions\Tests\Entities\Blank b",
+            "SELECT JSON_LOOSE('{\"key1\":123}') AS sclr_0 FROM Blank b0_"
+        );
+    }
+}

--- a/tests/Query/Functions/Mariadb/JsonNormalizeTest.php
+++ b/tests/Query/Functions/Mariadb/JsonNormalizeTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mariadb;
+
+use Scienta\DoctrineJsonFunctions\Tests\Query\MariadbTestCase;
+
+class JsonNormalizeTest extends MariadbTestCase
+{
+    public function testJsonNormalize()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSON_NORMALIZE('{\"key1\":123}') from Scienta\DoctrineJsonFunctions\Tests\Entities\Blank b",
+            "SELECT JSON_NORMALIZE('{\"key1\":123}') AS sclr_0 FROM Blank b0_"
+        );
+    }
+}

--- a/tests/Query/Functions/Mariadb/JsonQueryTest.php
+++ b/tests/Query/Functions/Mariadb/JsonQueryTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mariadb;
+
+use Scienta\DoctrineJsonFunctions\Tests\Query\MariadbTestCase;
+
+class JsonQueryTest extends MariadbTestCase
+{
+    public function testJsonQuery()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSON_QUERY('{\"key1\":123}', '$.key1') from Scienta\DoctrineJsonFunctions\Tests\Entities\Blank b",
+            "SELECT JSON_QUERY('{\"key1\":123}', '$.key1') AS sclr_0 FROM Blank b0_"
+        );
+    }
+}

--- a/tests/Query/Functions/Mysql/JsonMergePatchTest.php
+++ b/tests/Query/Functions/Mysql/JsonMergePatchTest.php
@@ -4,7 +4,7 @@ namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
 
 use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
 
-class JsonMergePatchTestTest extends MysqlTestCase
+class JsonMergePatchTest extends MysqlTestCase
 {
     public function testJsonMergePatch()
     {

--- a/tests/Query/Functions/Mysql/JsonMergePreserveTest.php
+++ b/tests/Query/Functions/Mysql/JsonMergePreserveTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Mysql;
+
+use Scienta\DoctrineJsonFunctions\Tests\Query\MysqlTestCase;
+
+class JsonMergePreserveTest extends MysqlTestCase
+{
+    public function testJsonMergePreserve()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSON_MERGE_PRESERVE('[1, 2]', '[true, false]') from Scienta\DoctrineJsonFunctions\Tests\Entities\Blank b",
+            "SELECT JSON_MERGE_PRESERVE('[1, 2]', '[true, false]') AS sclr_0 FROM Blank b0_"
+        );
+    }
+
+    public function testJsonMergePreserveMore()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSON_MERGE_PRESERVE('[1, 2]', '[true, false]', '[true, false]', '[true, false]') from Scienta\DoctrineJsonFunctions\Tests\Entities\Blank b",
+            "SELECT JSON_MERGE_PRESERVE('[1, 2]', '[true, false]', '[true, false]', '[true, false]') AS sclr_0 FROM Blank b0_"
+        );
+    }
+}

--- a/tests/Query/MariadbTestCase.php
+++ b/tests/Query/MariadbTestCase.php
@@ -27,5 +27,11 @@ abstract class MariadbTestCase extends DbTestCase
     {
         $configuration->addCustomStringFunction(DqlFunctions\JsonValue::FUNCTION_NAME, DqlFunctions\JsonValue::class);
         $configuration->addCustomStringFunction(DqlFunctions\JsonExists::FUNCTION_NAME, DqlFunctions\JsonExists::class);
+        $configuration->addCustomStringFunction(DqlFunctions\JsonQuery::FUNCTION_NAME, DqlFunctions\JsonQuery::class);
+        $configuration->addCustomStringFunction(DqlFunctions\JsonCompact::FUNCTION_NAME, DqlFunctions\JsonCompact::class);
+        $configuration->addCustomStringFunction(DqlFunctions\JsonDetailed::FUNCTION_NAME, DqlFunctions\JsonDetailed::class);
+        $configuration->addCustomStringFunction(DqlFunctions\JsonLoose::FUNCTION_NAME, DqlFunctions\JsonLoose::class);
+        $configuration->addCustomStringFunction(DqlFunctions\JsonEquals::FUNCTION_NAME, DqlFunctions\JsonEquals::class);
+        $configuration->addCustomStringFunction(DqlFunctions\JsonNormalize::FUNCTION_NAME, DqlFunctions\JsonNormalize::class);
     }
 }

--- a/tests/Query/MysqlTestCase.php
+++ b/tests/Query/MysqlTestCase.php
@@ -37,6 +37,7 @@ abstract class MysqlTestCase extends DbTestCase
         $configuration->addCustomStringFunction(DqlFunctions\JsonKeys::FUNCTION_NAME, DqlFunctions\JsonKeys::class);
         $configuration->addCustomStringFunction(DqlFunctions\JsonLength::FUNCTION_NAME, DqlFunctions\JsonLength::class);
         $configuration->addCustomStringFunction(DqlFunctions\JsonMerge::FUNCTION_NAME, DqlFunctions\JsonMerge::class);
+        $configuration->addCustomStringFunction(DqlFunctions\JsonMergePreserve::FUNCTION_NAME, DqlFunctions\JsonMergePreserve::class);
         $configuration->addCustomStringFunction(DqlFunctions\JsonMergePatch::FUNCTION_NAME, DqlFunctions\JsonMergePatch::class);
         $configuration->addCustomStringFunction(DqlFunctions\JsonObject::FUNCTION_NAME, DqlFunctions\JsonObject::class);
         $configuration->addCustomStringFunction(DqlFunctions\JsonPretty::FUNCTION_NAME, DqlFunctions\JsonPretty::class);


### PR DESCRIPTION
This PR add missing JSON function for MariaDB.
I also added a missing JSON function for MySQL which is compatible with MariaDB (JSON_MERGE_PRESERVE)

I updated the doc and test accordingly.

I also added a line in the doc mentionning that MySQL functions could be used as it with MariaDB when they are comaptible (which is almost everytime the case)
I did that because when I started reading the doc, I didn't understand I could do that.

I guess this PR could also close #28 