### PR TITLE
Add Support for PostgreSQL jsonb_insert Function

### DIFF
--- a/src/Query/AST/Functions/Postgresql/JsonbInsert.php
+++ b/src/Query/AST/Functions/Postgresql/JsonbInsert.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Postgresql;
+
+/**
+ * "JSONB_INSERT" "(" StringPrimary "," StringPrimary "," StringPrimary ")".
+ */
+class JsonbInsert extends PostgresqlJsonFunctionNode
+{
+    public const FUNCTION_NAME = 'JSONB_INSERT';
+
+    /** @var string[] */
+    protected $requiredArgumentTypes = [self::STRING_PRIMARY_ARG, self::STRING_PRIMARY_ARG, self::STRING_PRIMARY_ARG];
+
+    /** @var string[] */
+    protected $optionalArgumentTypes = [self::STRING_PRIMARY_ARG];
+}

--- a/tests/Query/Functions/Postgresql/JsonbInsertTest.php
+++ b/tests/Query/Functions/Postgresql/JsonbInsertTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Postgresql;
+
+use Scienta\DoctrineJsonFunctions\Tests\Query\PostgresqlTestCase;
+
+class JsonbInsertTest extends PostgresqlTestCase
+{
+    public function testSelect()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSONB_INSERT(d.jsonCol,'{0}',d.jsonData) FROM Scienta\DoctrineJsonFunctions\Tests\Entities\JsonData d",
+            "SELECT jsonb_insert(j0_.jsonCol, '{0}', j0_.jsonData) AS sclr_0 FROM JsonData j0_"
+        );
+    }
+}

--- a/tests/Query/PostgresqlTestCase.php
+++ b/tests/Query/PostgresqlTestCase.php
@@ -28,6 +28,7 @@ abstract class PostgresqlTestCase extends DbTestCase
     public static function loadDqlFunctions(Configuration $configuration)
     {
         $configuration->addCustomStringFunction(DqlFunctions\JsonbContains::FUNCTION_NAME, DqlFunctions\JsonbContains::class);
+        $configuration->addCustomStringFunction(DqlFunctions\JsonbInsert::FUNCTION_NAME, DqlFunctions\JsonbInsert::class);
         $configuration->addCustomStringFunction(DqlFunctions\JsonGetText::FUNCTION_NAME, DqlFunctions\JsonGetText::class);
     }
 }


### PR DESCRIPTION
This pull request introduces support for the `jsonb_insert` function in PostgreSQL, allowing users to efficiently insert JSONB data into a specified path within a JSONB column.

Please review and provide feedback on the implementation. Thank you!