### PR TITLE
Add unit tests for psql JsonbExists functions

### DIFF
--- a/tests/Query/Functions/Postgresql/JsonbExistsAllTest.php
+++ b/tests/Query/Functions/Postgresql/JsonbExistsAllTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Postgresql;
+
+use Scienta\DoctrineJsonFunctions\Tests\Query\PostgresqlTestCase;
+
+class JsonbExistsAllTest extends PostgresqlTestCase
+{
+    public function testSelect()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSONB_EXISTS_ALL(d.jsonCol, '{a,b}') FROM Scienta\DoctrineJsonFunctions\Tests\Entities\JsonData d",
+            "SELECT jsonb_exists_all(j0_.jsonCol, '{a,b}') AS sclr_0 FROM JsonData j0_"
+        );
+    }
+
+    public function testWhere()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT d.id FROM Scienta\DoctrineJsonFunctions\Tests\Entities\JsonData d WHERE JSONB_EXISTS_ALL(d.jsonCol, '{a,b}') = true",
+            "SELECT j0_.id AS id_0 FROM JsonData j0_ WHERE jsonb_exists_all(j0_.jsonCol, '{a,b}') = true"
+        );
+    }
+}

--- a/tests/Query/Functions/Postgresql/JsonbExistsAnyTest.php
+++ b/tests/Query/Functions/Postgresql/JsonbExistsAnyTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scienta\DoctrineJsonFunctions\Tests\Query\Functions\Postgresql;
+
+use Scienta\DoctrineJsonFunctions\Tests\Query\PostgresqlTestCase;
+
+class JsonbExistsAnyTest extends PostgresqlTestCase
+{
+    public function testSelect()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT JSONB_EXISTS_ANY(d.jsonCol, '{a,b}') FROM Scienta\DoctrineJsonFunctions\Tests\Entities\JsonData d",
+            "SELECT jsonb_exists_any(j0_.jsonCol, '{a,b}') AS sclr_0 FROM JsonData j0_"
+        );
+    }
+
+    public function testWhere()
+    {
+        $this->assertDqlProducesSql(
+            "SELECT d.id FROM Scienta\DoctrineJsonFunctions\Tests\Entities\JsonData d WHERE JSONB_EXISTS_ANY(d.jsonCol, '{a,b}') = true",
+            "SELECT j0_.id AS id_0 FROM JsonData j0_ WHERE jsonb_exists_any(j0_.jsonCol, '{a,b}') = true"
+        );
+    }
+}

--- a/tests/Query/PostgresqlTestCase.php
+++ b/tests/Query/PostgresqlTestCase.php
@@ -30,5 +30,7 @@ abstract class PostgresqlTestCase extends DbTestCase
         $configuration->addCustomStringFunction(DqlFunctions\JsonbContains::FUNCTION_NAME, DqlFunctions\JsonbContains::class);
         $configuration->addCustomStringFunction(DqlFunctions\JsonbInsert::FUNCTION_NAME, DqlFunctions\JsonbInsert::class);
         $configuration->addCustomStringFunction(DqlFunctions\JsonGetText::FUNCTION_NAME, DqlFunctions\JsonGetText::class);
+        $configuration->addCustomStringFunction(DqlFunctions\JsonbExistsAny::FUNCTION_NAME, DqlFunctions\JsonbExistsAny::class);
+        $configuration->addCustomStringFunction(DqlFunctions\JsonbExistsAll::FUNCTION_NAME, DqlFunctions\JsonbExistsAll::class);
     }
 }


### PR DESCRIPTION
These missing unit tests are not only helpful as unit tests, but also provide code samples for those looking for how to use these functions.