### PR TITLE
Fix validatePlatform for MariaDB, check for instance of MariaDBPlatform

### DIFF
--- a/src/DBALCompatibility.php
+++ b/src/DBALCompatibility.php
@@ -35,4 +35,15 @@ final class DBALCompatibility
 
         return 'Doctrine\DBAL\Platforms\SqlitePlatform';
     }
+
+    public static function mariaDBPlatform(): string
+    {
+        if (!class_exists('\Doctrine\DBAL\Platforms\MariaDBPlatform')) {
+            // In DBAL versions prior to 3.3, MariaDB used or extended the MySQL platform
+            return '\Doctrine\DBAL\Platforms\MySQLPlatform';
+        }
+
+        // DBAL 3.3 and onwards
+        return '\Doctrine\DBAL\Platforms\MariaDBPlatform';
+    }
 }

--- a/src/Query/AST/Functions/Mariadb/MariadbJsonFunctionNode.php
+++ b/src/Query/AST/Functions/Mariadb/MariadbJsonFunctionNode.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mariadb;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\DBALCompatibility;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonFunctionNode;
@@ -18,7 +17,7 @@ abstract class MariadbJsonFunctionNode extends AbstractJsonFunctionNode
      */
     protected function validatePlatform(SqlWalker $sqlWalker): void
     {
-        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof MySQLPlatform) {
+        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof (DBALCompatibility::mariaDBPlatform())) {
             throw DBALCompatibility::notSupportedPlatformException(static::FUNCTION_NAME);
         }
     }

--- a/tests/Query/MariadbTestCase.php
+++ b/tests/Query/MariadbTestCase.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Scienta\DoctrineJsonFunctions\Tests\Query;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Configuration;
+use Scienta\DoctrineJsonFunctions\DBALCompatibility;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mariadb as DqlFunctions;
 use Scienta\DoctrineJsonFunctions\Tests\Mocks\ConnectionMock;
 
@@ -17,7 +17,7 @@ abstract class MariadbTestCase extends DbTestCase
 
         /** @var ConnectionMock $conn */
         $conn = $this->entityManager->getConnection();
-        $conn->setDatabasePlatform(new MySQLPlatform());
+        $conn->setDatabasePlatform(new (DBALCompatibility::mariaDBPlatform())());
 
         self::loadDqlFunctions($this->configuration);
     }


### PR DESCRIPTION
#### Fix validatePlatform for MariaDB, check for instance of MariaDBPlatform

Versions of DBAL before 3.3 used or extended the MySQLPlatform when
connecting to MariaDB. Because of this the platform check was
requiring an instance of MySQLPlatform.

This commit fixes MariaDB compatibility with DBAL >=3.3, while remaining
 compatible with versions prior to that (for now).

Fixes #113