### PR TITLE
Compatibility with DBAL4 for MAriaDB functions

### DIFF
--- a/src/DBALCompatibility.php
+++ b/src/DBALCompatibility.php
@@ -46,4 +46,15 @@ final class DBALCompatibility
         // DBAL 3.3 and onwards
         return '\Doctrine\DBAL\Platforms\MariaDBPlatform';
     }
+
+    public static function mysqlAndMariaDBSharedPlatform(): string
+    {
+        if (!class_exists('\Doctrine\DBAL\Platforms\AbstractMySQLPlatform')) {
+            // In DBAL versions prior to 3.3, MariaDB used or extended the MySQL platform
+            return '\Doctrine\DBAL\Platforms\MySQLPlatform';
+        }
+
+        // DBAL 3.3 and onwards
+        return '\Doctrine\DBAL\Platforms\AbstractMySQLPlatform';
+    }
 }

--- a/src/Query/AST/Functions/Mysql/MysqlJsonFunctionNode.php
+++ b/src/Query/AST/Functions/Mysql/MysqlJsonFunctionNode.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\DBALCompatibility;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonFunctionNode;
@@ -18,7 +17,7 @@ abstract class MysqlJsonFunctionNode extends AbstractJsonFunctionNode
      */
     protected function validatePlatform(SqlWalker $sqlWalker): void
     {
-        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof MySQLPlatform) {
+        if (!$sqlWalker->getConnection()->getDatabasePlatform() instanceof (DBALCompatibility::mysqlAndMariaDBSharedPlatform())) {
             throw DBALCompatibility::notSupportedPlatformException(static::FUNCTION_NAME);
         }
     }


### PR DESCRIPTION
This simple PR solves #116 and #117. The root cause here is that since DBAL 4 MAriaDB platforms are no longer extending MySQL platform, but only `AbstractMySQLPlatform`. Therefore functions that are identical between MariaDB and MySQL dialects became unusable with `Operation "JSON_CONTAINS" is not supported by platform.` or similar.

I have tested this change on an existing and pretty large project and everything seems to be working as expected.