### PR TITLE
Correctly rename MysqlMariadb shared node as such

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /composer.lock
 /vendor
 .phpunit.result.cache
+.phpunit.cache
 .phpcs-cache

--- a/src/Query/AST/Functions/AbstractJsonFunctionNode.php
+++ b/src/Query/AST/Functions/AbstractJsonFunctionNode.php
@@ -14,6 +14,9 @@ use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\TokenType;
 
+/**
+ * @internal
+ */
 abstract class AbstractJsonFunctionNode extends FunctionNode
 {
     public const FUNCTION_NAME = null;

--- a/src/Query/AST/Functions/AbstractJsonOperatorFunctionNode.php
+++ b/src/Query/AST/Functions/AbstractJsonOperatorFunctionNode.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions;
 
+/**
+ * @internal
+ */
 abstract class AbstractJsonOperatorFunctionNode extends AbstractJsonFunctionNode
 {
     /** @var string[] */

--- a/src/Query/AST/Functions/Mariadb/MariadbJsonFunctionNode.php
+++ b/src/Query/AST/Functions/Mariadb/MariadbJsonFunctionNode.php
@@ -9,6 +9,9 @@ use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\DBALCompatibility;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonFunctionNode;
 
+/**
+ * @internal
+ */
 abstract class MariadbJsonFunctionNode extends AbstractJsonFunctionNode
 {
     /**

--- a/src/Query/AST/Functions/Mysql/JsonArray.php
+++ b/src/Query/AST/Functions/Mysql/JsonArray.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_ARRAY" "(" { NewValue }* ")"
  */
-class JsonArray extends MysqlJsonFunctionNode
+class JsonArray extends MysqlAndMariadbJsonFunctionNode
 {
 	public const FUNCTION_NAME = 'JSON_ARRAY';
 

--- a/src/Query/AST/Functions/Mysql/JsonArrayAgg.php
+++ b/src/Query/AST/Functions/Mysql/JsonArrayAgg.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_ARRAYAGG" "(" NewValue ")"
  */
-class JsonArrayAgg extends MysqlJsonFunctionNode
+class JsonArrayAgg extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_ARRAYAGG';
 

--- a/src/Query/AST/Functions/Mysql/JsonArrayAppend.php
+++ b/src/Query/AST/Functions/Mysql/JsonArrayAppend.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_ARRAY_APPEND" "(" StringPrimary "," StringPrimary "," NewValue { "," StringPrimary "," NewValue }* ")"
  */
-class JsonArrayAppend extends MysqlJsonFunctionNode
+class JsonArrayAppend extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_ARRAY_APPEND';
 

--- a/src/Query/AST/Functions/Mysql/JsonArrayInsert.php
+++ b/src/Query/AST/Functions/Mysql/JsonArrayInsert.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_ARRAY_INSERT" "(" StringPrimary "," StringPrimary "," NewValue { "," StringPrimary "," NewValue }* ")"
  */
-class JsonArrayInsert extends MysqlJsonFunctionNode
+class JsonArrayInsert extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_ARRAY_INSERT';
 

--- a/src/Query/AST/Functions/Mysql/JsonContains.php
+++ b/src/Query/AST/Functions/Mysql/JsonContains.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_CONTAINS" "(" StringPrimary "," StringPrimary {"," StringPrimary } ")"
  */
-class JsonContains extends MysqlJsonFunctionNode
+class JsonContains extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_CONTAINS';
 

--- a/src/Query/AST/Functions/Mysql/JsonDepth.php
+++ b/src/Query/AST/Functions/Mysql/JsonDepth.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_DEPTH" "(" StringPrimary ")"
  */
-class JsonDepth extends MysqlJsonFunctionNode
+class JsonDepth extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_DEPTH';
 

--- a/src/Query/AST/Functions/Mysql/JsonExtract.php
+++ b/src/Query/AST/Functions/Mysql/JsonExtract.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_EXTRACT" "(" StringPrimary "," StringPrimary {"," StringPrimary }* ")"
  */
-class JsonExtract extends MysqlJsonFunctionNode
+class JsonExtract extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_EXTRACT';
 

--- a/src/Query/AST/Functions/Mysql/JsonInsert.php
+++ b/src/Query/AST/Functions/Mysql/JsonInsert.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_INSERT" "(" StringPrimary "," StringPrimary "," NewValue { "," StringPrimary "," NewValue }* ")"
  */
-class JsonInsert extends MysqlJsonFunctionNode
+class JsonInsert extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_INSERT';
 

--- a/src/Query/AST/Functions/Mysql/JsonKeys.php
+++ b/src/Query/AST/Functions/Mysql/JsonKeys.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_KEYS" "(" StringPrimary {"," StringPrimary } ")"
  */
-class JsonKeys extends MysqlJsonFunctionNode
+class JsonKeys extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_KEYS';
 

--- a/src/Query/AST/Functions/Mysql/JsonLength.php
+++ b/src/Query/AST/Functions/Mysql/JsonLength.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_LENGTH" "(" StringPrimary {"," StringPrimary } ")"
  */
-class JsonLength extends MysqlJsonFunctionNode
+class JsonLength extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_LENGTH';
 

--- a/src/Query/AST/Functions/Mysql/JsonMerge.php
+++ b/src/Query/AST/Functions/Mysql/JsonMerge.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_MERGE" "(" StringPrimary "," StringPrimary { "," StringPrimary }* ")"
  */
-class JsonMerge extends MysqlJsonFunctionNode
+class JsonMerge extends MysqlAndMariadbJsonFunctionNode
 {
 	public const FUNCTION_NAME = 'JSON_MERGE';
 

--- a/src/Query/AST/Functions/Mysql/JsonMergePatch.php
+++ b/src/Query/AST/Functions/Mysql/JsonMergePatch.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_MERGE_PATCH" "(" StringPrimary "," StringPrimary { "," StringPrimary }* ")"
  */
-class JsonMergePatch extends MysqlJsonFunctionNode
+class JsonMergePatch extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_MERGE_PATCH';
 

--- a/src/Query/AST/Functions/Mysql/JsonMergePreserve.php
+++ b/src/Query/AST/Functions/Mysql/JsonMergePreserve.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_MERGE_PRESERVE" "(" StringPrimary "," StringPrimary { "," StringPrimary }* ")"
  */
-class JsonMergePreserve extends MysqlJsonFunctionNode
+class JsonMergePreserve extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_MERGE_PRESERVE';
 

--- a/src/Query/AST/Functions/Mysql/JsonObject.php
+++ b/src/Query/AST/Functions/Mysql/JsonObject.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_OBJECT" "(" { string "," NewValue }* ")"
  */
-class JsonObject extends MysqlJsonFunctionNode
+class JsonObject extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_OBJECT';
 

--- a/src/Query/AST/Functions/Mysql/JsonObjectAgg.php
+++ b/src/Query/AST/Functions/Mysql/JsonObjectAgg.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_OBJECTAGG" "(" StringPrimary "," NewValue ")"
  */
-class JsonObjectAgg extends MysqlJsonFunctionNode
+class JsonObjectAgg extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_OBJECTAGG';
 

--- a/src/Query/AST/Functions/Mysql/JsonOverlaps.php
+++ b/src/Query/AST/Functions/Mysql/JsonOverlaps.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_OVERLAPS" "(" StringPrimary "," StringPrimary ")"
  */
-class JsonOverlaps extends MysqlJsonFunctionNode
+class JsonOverlaps extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_OVERLAPS';
 

--- a/src/Query/AST/Functions/Mysql/JsonPretty.php
+++ b/src/Query/AST/Functions/Mysql/JsonPretty.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_PRETTY" "(" NewValue ")"
  */
-class JsonPretty extends MysqlJsonFunctionNode
+class JsonPretty extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_PRETTY';
 

--- a/src/Query/AST/Functions/Mysql/JsonQuote.php
+++ b/src/Query/AST/Functions/Mysql/JsonQuote.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_QUOTE" "(" NewValue ")"
  */
-class JsonQuote extends MysqlJsonFunctionNode
+class JsonQuote extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_QUOTE';
 

--- a/src/Query/AST/Functions/Mysql/JsonRemove.php
+++ b/src/Query/AST/Functions/Mysql/JsonRemove.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_REMOVE" "(" StringPrimary "," StringPrimary {"," StringPrimary }* ")"
  */
-class JsonRemove extends MysqlJsonFunctionNode
+class JsonRemove extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_REMOVE';
 

--- a/src/Query/AST/Functions/Mysql/JsonReplace.php
+++ b/src/Query/AST/Functions/Mysql/JsonReplace.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_REPLACE" "(" StringPrimary "," StringPrimary "," NewValue { "," StringPrimary "," NewValue }* ")"
  */
-class JsonReplace extends MysqlJsonFunctionNode
+class JsonReplace extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_REPLACE';
 

--- a/src/Query/AST/Functions/Mysql/JsonSearch.php
+++ b/src/Query/AST/Functions/Mysql/JsonSearch.php
@@ -13,7 +13,7 @@ use Scienta\DoctrineJsonFunctions\DBALCompatibility;
 /**
  * "JSON_SEARCH" "(" StringPrimary "," ["one" | "all"] "," StringPrimary {"," NewValue { "," StringPrimary }* } ")"
  */
-class JsonSearch extends MysqlJsonFunctionNode
+class JsonSearch extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_SEARCH';
 

--- a/src/Query/AST/Functions/Mysql/JsonSet.php
+++ b/src/Query/AST/Functions/Mysql/JsonSet.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_SET" "(" StringPrimary "," StringPrimary "," NewValue { "," StringPrimary "," NewValue }* ")"
  */
-class JsonSet extends MysqlJsonFunctionNode
+class JsonSet extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_SET';
 

--- a/src/Query/AST/Functions/Mysql/JsonType.php
+++ b/src/Query/AST/Functions/Mysql/JsonType.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_TYPE" "(" StringPrimary ")"
  */
-class JsonType extends MysqlJsonFunctionNode
+class JsonType extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_TYPE';
 

--- a/src/Query/AST/Functions/Mysql/JsonUnquote.php
+++ b/src/Query/AST/Functions/Mysql/JsonUnquote.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_UNQUOTE" "(" StringPrimary ")"
  */
-class JsonUnquote extends MysqlJsonFunctionNode
+class JsonUnquote extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_UNQUOTE';
 

--- a/src/Query/AST/Functions/Mysql/JsonValid.php
+++ b/src/Query/AST/Functions/Mysql/JsonValid.php
@@ -7,7 +7,7 @@ namespace Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql;
 /**
  * "JSON_VALID" "(" StringPrimary ")"
  */
-class JsonValid extends MysqlJsonFunctionNode
+class JsonValid extends MysqlAndMariadbJsonFunctionNode
 {
     public const FUNCTION_NAME = 'JSON_VALID';
 

--- a/src/Query/AST/Functions/Mysql/MysqlAndMariadbJsonFunctionNode.php
+++ b/src/Query/AST/Functions/Mysql/MysqlAndMariadbJsonFunctionNode.php
@@ -9,7 +9,10 @@ use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\DBALCompatibility;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonFunctionNode;
 
-abstract class MysqlJsonFunctionNode extends AbstractJsonFunctionNode
+/**
+ * @internal
+ */
+abstract class MysqlAndMariadbJsonFunctionNode extends AbstractJsonFunctionNode
 {
     /**
      * @param SqlWalker $sqlWalker

--- a/src/Query/AST/Functions/Postgresql/PostgresqlJsonFunctionNode.php
+++ b/src/Query/AST/Functions/Postgresql/PostgresqlJsonFunctionNode.php
@@ -10,6 +10,9 @@ use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\DBALCompatibility;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonFunctionNode;
 
+/**
+ * @internal
+ */
 abstract class PostgresqlJsonFunctionNode extends AbstractJsonFunctionNode
 {
     /**

--- a/src/Query/AST/Functions/Postgresql/PostgresqlJsonOperatorFunctionNode.php
+++ b/src/Query/AST/Functions/Postgresql/PostgresqlJsonOperatorFunctionNode.php
@@ -10,6 +10,9 @@ use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\DBALCompatibility;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonOperatorFunctionNode;
 
+/**
+ * @internal
+ */
 abstract class PostgresqlJsonOperatorFunctionNode extends AbstractJsonOperatorFunctionNode
 {
     public const OPERATOR = null;

--- a/src/Query/AST/Functions/Sqlite/SqliteJsonFunctionNode.php
+++ b/src/Query/AST/Functions/Sqlite/SqliteJsonFunctionNode.php
@@ -9,6 +9,9 @@ use Doctrine\ORM\Query\SqlWalker;
 use Scienta\DoctrineJsonFunctions\DBALCompatibility;
 use Scienta\DoctrineJsonFunctions\Query\AST\Functions\AbstractJsonFunctionNode;
 
+/**
+ * @internal
+ */
 abstract class SqliteJsonFunctionNode extends AbstractJsonFunctionNode
 {
     /**


### PR DESCRIPTION
Mark platform-specific nodes as internal
Rename mysql(shared) function node to include mariadb Prepare the way for mysql-only json functions