### PR TITLE
Make JSON_VALUE() RETURNING arg for mysql optional

### DIFF
--- a/src/Query/AST/Functions/Mysql/JsonValue.php
+++ b/src/Query/AST/Functions/Mysql/JsonValue.php
@@ -14,7 +14,8 @@ use function implode;
 use function sprintf;
 
 /**
- * "JSON_VALUE" "(" StringPrimary "," StringPrimary "RETURNING" TypeExpression ")"
+ * "JSON_VALUE" "(" StringPrimary "," StringPrimary {"," TypeExpression } ")"
+ * @example JSON_VALUE('{"item": "shoes", "price": "49.95"}', '$.item')
  * @example JSON_VALUE('{"item": "shoes", "price": "49.95"}', '$.price', DECIMAL(4,2))
  */
 class JsonValue extends MysqlJsonFunctionNode
@@ -24,7 +25,7 @@ class JsonValue extends MysqlJsonFunctionNode
     /** @var list<Node> */
     private array $jsonArguments = [];
 
-    private string | null $returningType;
+    private string | int | null $returningType = null;
 
     public function parse(Parser $parser): void
     {
@@ -37,33 +38,30 @@ class JsonValue extends MysqlJsonFunctionNode
 
         $this->jsonArguments[] = $parser->StringPrimary();
 
-        $parser->match(TokenType::T_COMMA);
+		if ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
+			$parser->match(TokenType::T_COMMA);
 
-        // match complex returning types
-        $parser->match(TokenType::T_IDENTIFIER);
-        $this->returningType = $parser->getLexer()->token->value;
+			// match complex returning types
+			$parser->match(TokenType::T_IDENTIFIER);
+			$this->returningType = $parser->getLexer()->token->value;
 
-        if ($parser->getLexer()->isNextToken(TokenType::T_OPEN_PARENTHESIS)) {
-            $parser->match(TokenType::T_OPEN_PARENTHESIS);
-            $parameter = $parser->Literal();
-            $parameters = [$parameter->value];
+			if ($parser->getLexer()->isNextToken(TokenType::T_OPEN_PARENTHESIS)) {
+				$parser->match(TokenType::T_OPEN_PARENTHESIS);
+				$parameter = $parser->Literal();
+				$parameters = [$parameter->value];
 
-            if ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
-                while ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
-                    $parser->match(TokenType::T_COMMA);
-                    $parameter    = $parser->Literal();
-                    $parameters[] = $parameter->value;
-                }
-            }
+				if ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
+					while ($parser->getLexer()->isNextToken(TokenType::T_COMMA)) {
+						$parser->match(TokenType::T_COMMA);
+						$parameter    = $parser->Literal();
+						$parameters[] = $parameter->value;
+					}
+				}
 
-            $parser->match(TokenType::T_CLOSE_PARENTHESIS);
-            $this->returningType .= '(' . implode(',', $parameters) . ')';
-        }
-        $argumentParsed = $this->parseArguments($parser, $this->requiredArgumentTypes);
-
-        if (!empty($this->optionalArgumentTypes)) {
-            $this->parseOptionalArguments($parser, $argumentParsed);
-        }
+				$parser->match(TokenType::T_CLOSE_PARENTHESIS);
+				$this->returningType .= '(' . implode(',', $parameters) . ')';
+			}
+		}
 
         $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
@@ -87,6 +85,10 @@ class JsonValue extends MysqlJsonFunctionNode
                 $jsonStringArguments[] = $jsonArgument->dispatch($sqlWalker);
             }
         }
+
+		if ($this->returningType === null) {
+			return sprintf('%s(%s)', $this->getSQLFunction(), implode(', ', $jsonStringArguments));
+		}
 
         return sprintf(
             '%s(%s RETURNING %s)',

--- a/tests/Query/Functions/Mysql/JsonValueTest.php
+++ b/tests/Query/Functions/Mysql/JsonValueTest.php
@@ -11,6 +11,14 @@ class JsonValueTest extends MysqlTestCase
     public function testJsonValueForData()
     {
         $this->assertDqlProducesSql(
+            "SELECT JSON_VALUE(j.jsonData, '$.a') FROM Scienta\DoctrineJsonFunctions\Tests\Entities\JsonData j",
+            "SELECT JSON_VALUE(j0_.jsonData, '$.a') AS sclr_0 FROM JsonData j0_"
+        );
+    }
+
+    public function testJsonValueReturningUnsigned()
+    {
+        $this->assertDqlProducesSql(
             "SELECT JSON_VALUE(j.jsonData, '$.a', UNSIGNED) FROM Scienta\DoctrineJsonFunctions\Tests\Entities\JsonData j",
             "SELECT JSON_VALUE(j0_.jsonData, '$.a' RETURNING UNSIGNED) AS sclr_0 FROM JsonData j0_"
         );


### PR DESCRIPTION
See https://dev.mysql.com/doc/refman/8.4/en/json-search-functions.html#function_json-value
The type-argument after RETURNING is optional for JSON_VALUE()