### PR TITLE
 Fix Override polyfill to include TARGET_PROPERTY

### DIFF
--- a/polyfill/override.php
+++ b/polyfill/override.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
 // a no-op class for PHP 8.1 and 8.2 so the attribute can be used in code
 // that targets multiple PHP versions.
 if (PHP_VERSION_ID < 80300) {
-    #[Attribute(Attribute::TARGET_METHOD)]
+    #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
     class Override
     {
     }


### PR DESCRIPTION
The #[Override] polyfill only declares Attribute::TARGET_METHOD, but PHP 8.4+ natively supports #[Override] on property hooks (TARGET_METHOD | TARGET_PROPERTY). Since the polyfill is registered in Composer's files autoload,
  static analysis tools like PHPStan pick up the restrictive definition over the native one, causing attribute.target errors for consumers using #[Override] on property hooks.